### PR TITLE
put config on initializers; remove whitespace to prevent unnecessary diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ rails generate semantic_navigation:install
 
 ###Quick start
 
-Configure your navigation in config/semantic_navigation.rb
+Configure your navigation in config/initializers/semantic_navigation.rb
 
 <pre><code>
 SemanticNavigation::Configuration.run do
@@ -66,4 +66,4 @@ For the information of how to configure and render your navigation read the <a h
 Dependence:
 
 * Ruby >= 1.9.2
-* Rails >= 3.0.0 
+* Rails >= 3.0.0

--- a/lib/generators/semantic_navigation/install/install_generator.rb
+++ b/lib/generators/semantic_navigation/install/install_generator.rb
@@ -3,7 +3,7 @@ module SemanticNavigation
     class InstallGenerator < ::Rails::Generators::Base
       source_root File.expand_path("../templates", __FILE__)
       desc "This generator creates config file for your navigation"
-      
+
       def add_semantic_navigation
         puts <<-EOM
         +===============================================================+
@@ -12,7 +12,7 @@ module SemanticNavigation
         | http://github.com/fr33z3/semantic_navigation/wiki.            |
         +===============================================================+
         EOM
-        copy_file "semantic_navigation.rb", "config/semantic_navigation.rb"
+        copy_file "semantic_navigation.rb", "config/initializers/semantic_navigation.rb"
         copy_file "semantic_navigation.en.yml", "config/locales/semantic_navigation.en.yml"
       end
     end

--- a/lib/generators/semantic_navigation/install/templates/semantic_navigation.rb
+++ b/lib/generators/semantic_navigation/install/templates/semantic_navigation.rb
@@ -2,20 +2,20 @@
 SemanticNavigation::Configuration.run do
   # Read wiki https://github.com/fr33z3/semantic_navigation/wiki to lear about
   # semantic_navigation configuration
-  
+
   #Override renderer default styles:
   #styles_for :list do
   #  show_navigation_active_class true
   #  navigation_active_class [:some_active_class]
   #end
-  
+
   # You can register your custom renderer:
   #register_renderer :some_renderer, SomeRendererClass
-  
+
   # The example of the navigation:
   #navigate :navigation do
   #  header :header_item, :name => 'Header Item'
-  #  item :first_item, :first_item_route, :ico => 'user' do 
+  #  item :first_item, :first_item_route, :ico => 'user' do
   #    item :sub_item, :sub_item_route do
   #      item :sub_sub_item, :sub_sub_item_route
   #    end
@@ -24,6 +24,6 @@ SemanticNavigation::Configuration.run do
   #  divider
   #  item :second_item, :second_item_route
   #end
-  
+
 end
 

--- a/lib/semantic_navigation/configuration.rb
+++ b/lib/semantic_navigation/configuration.rb
@@ -1,6 +1,6 @@
 module SemanticNavigation
   class Configuration
-    
+
     @@view_object = nil
     @@navigations = {}
     @@renderers = {}
@@ -9,7 +9,7 @@ module SemanticNavigation
     def self.run(&block)
       self.class_eval &block if block_given?
     end
-    
+
     def self.navigate(id, options = {}, &block)
       options[:id] = id.to_sym
       options[:i18n_name] = "semantic_navigation.#{id}"
@@ -17,7 +17,7 @@ module SemanticNavigation
       navigation.instance_eval &block if block_given?
       @@navigations[id.to_sym] = navigation
     end
-    
+
     def render(menu_id, renderer_name, options, view_object)
       @@view_object = view_object
       renderer = @@renderers[renderer_name].new
@@ -25,21 +25,21 @@ module SemanticNavigation
         renderer.instance_eval &@@render_styles[renderer_name]
       end
       options.keys.each{|key| renderer.send "#{key}=", options[key]}
-      renderer.name = renderer_name      
+      renderer.name = renderer_name
       navigation = @@navigations[menu_id]
       navigation.mark_active
       navigation.render(renderer)
     end
-    
+
     def self.styles_for(name)
       @@render_styles[name.to_sym] = proc
     end
-       
+
     def self.register_renderer(*options)
       if options.count == 1
         name = options[0].name.demodulize.underscore.to_sym
         renderer_class = options[0]
-      elsif options.count == 2 
+      elsif options.count == 2
         name = options[0].to_sym
         renderer_class = options[1].is_a?(Symbol) ? @@renderers[options[1]] : options[1]
       end
@@ -51,7 +51,7 @@ module SemanticNavigation
         end
       "
     end
-    
+
     def self.view_object
       @@view_object
     end
@@ -59,7 +59,7 @@ module SemanticNavigation
     def self.view_object=(view_object)
       @@view_object = view_object
     end
-    
+
     def self.navigation(name)
       @@navigations[name]
     end

--- a/lib/semantic_navigation/core/base.rb
+++ b/lib/semantic_navigation/core/base.rb
@@ -1,14 +1,14 @@
 module SemanticNavigation
   module Core
-    class Base      
-      
+    class Base
+
       attr_accessor :id, :level, :classes, :active
       attr_writer :render_if
-      
+
       def render_if
         !@render_if.nil? ? view_object.instance_exec(self, &@render_if) : true
       end
-      
+
       def initialize(options, level)
         @level = level
         options.keys.each do |option_name|
@@ -20,9 +20,9 @@ module SemanticNavigation
         class_name = self.class.name.split('::').last.downcase
         renderer.send :"render_#{class_name}", self
       end
-      
+
       private
-      
+
       def view_object
         SemanticNavigation::Configuration.view_object
       end
@@ -38,7 +38,7 @@ module SemanticNavigation
         end
         result
       end
-      
-    end    
+
+    end
   end
 end

--- a/lib/semantic_navigation/core/leaf.rb
+++ b/lib/semantic_navigation/core/leaf.rb
@@ -2,7 +2,7 @@ module SemanticNavigation
   module Core
     class Leaf < Base
       attr_accessor :link_classes
-      
+
       def url
         urls.first
       end
@@ -10,14 +10,14 @@ module SemanticNavigation
       def initialize(options, level)
         super options, level
       end
-      
+
       def name(renderer_name = nil)
         rendering_name = @name
         rendering_name = rendering_name[renderer_name.to_sym] || rendering_name[:default] if rendering_name.is_a?(Hash)
         rendering_name = view_object.instance_eval(&rendering_name).to_s if rendering_name.is_a?(Proc)
         rendering_name || i18n_name(renderer_name)
       end
-      
+
       def mark_active
         if @url
           @active = urls.map{|u| current_page?(u) rescue false}.reduce(:"|")
@@ -45,7 +45,7 @@ module SemanticNavigation
           end
         end
       end
-      
-    end    
+
+    end
   end
 end

--- a/lib/semantic_navigation/core/navigation.rb
+++ b/lib/semantic_navigation/core/navigation.rb
@@ -2,7 +2,7 @@ module SemanticNavigation
   module Core
     class Navigation < Base
       attr_accessor :sub_elements
-      
+
       def initialize(options, level = 0)
         @sub_elements = []
         super options, level
@@ -10,7 +10,7 @@ module SemanticNavigation
 
       def item(id, url=nil, options={}, &block)
         options[:id] = id.to_sym
-        
+
         if url.is_a?(Array)
           options[:url] = [url].flatten(1).map{|url| decode_url(url)}
         else
@@ -18,7 +18,7 @@ module SemanticNavigation
         end
 
         options[:i18n_name] = @i18n_name
-        
+
         if block_given?
           element = Node.new(options, @level+1)
           element.instance_eval &block
@@ -32,7 +32,7 @@ module SemanticNavigation
             puts 'Warning: do not define `dividers` using `item` method. Use `divider` instead. This logic will be deprecated soon.'
           end
         end
-        
+
         @sub_elements.push element
       end
 
@@ -59,7 +59,7 @@ module SemanticNavigation
       end
 
       def mark_active
-        @sub_elements.each do |element| 
+        @sub_elements.each do |element|
           element.mark_active
         end
         @active = !@sub_elements.find{|element| element.active}.nil?
@@ -71,12 +71,12 @@ module SemanticNavigation
         if url.is_a? String
           controller_name, action_name = url.split('#')
           if controller_name && action_name
-            decoded_url = {:controller => controller_name, :action => action_name}  
-          end        
+            decoded_url = {:controller => controller_name, :action => action_name}
+          end
         end
         decoded_url || url
       end
-      
+
     end
   end
 end

--- a/lib/semantic_navigation/core/node.rb
+++ b/lib/semantic_navigation/core/node.rb
@@ -1,32 +1,32 @@
 module SemanticNavigation
   module Core
-    class Node < Navigation      
+    class Node < Navigation
       attr_accessor :link_classes, :node_classes
-      
+
       def url
         urls.first
       end
-      
+
       def initialize(options, level)
         @url = []
         super options, level
       end
-      
+
       def name(renderer_name = nil)
         rendering_name = @name
         rendering_name = rendering_name[renderer_name.to_sym] || rendering_name[:default] if rendering_name.is_a?(Hash)
         rendering_name = view_object.instance_eval(&rendering_name).to_s if rendering_name.is_a?(Proc)
         rendering_name || i18n_name(renderer_name)
       end
-      
+
       def mark_active
         @sub_elements.each{|element| element.mark_active}
         @active = urls.map{|u| current_page?(u) rescue false}.reduce(:"|")
         @active |= !@sub_elements.find{|element| element.active}.nil?
       end
-            
+
       private
-      
+
       def i18n_name(renderer_name = nil)
         name = I18n.t("#{@i18n_name}.#{@id}", :default => '')
         if name.is_a? Hash
@@ -41,10 +41,10 @@ module SemanticNavigation
             view_object.instance_eval(&url) rescue ''
           else
             url
-          end          
+          end
         end
       end
-      
+
     end
   end
 end

--- a/lib/semantic_navigation/railtie.rb
+++ b/lib/semantic_navigation/railtie.rb
@@ -2,7 +2,7 @@ require 'semantic_navigation/helper_methods'
 
 module SemanticNavigation
   class Railtie < Rails::Railtie
-   
+
     initializer "semantic_navigation.extend_helper_methods" do
       ActiveSupport.on_load :action_view do
         ActionView::Base.send :include, HelperMethods
@@ -16,7 +16,7 @@ module SemanticNavigation
       conf.register_renderer :bootstrap_tabs, TwitterBootstrap::Tabs
       conf.register_renderer :bootstrap_pills, TwitterBootstrap::Tabs
       conf.register_renderer :bootstrap_simple_nav, SemanticNavigation::Renderers::List
-      
+
       conf.styles_for :bootstrap_pills do
         navigation_default_classes [:nav, 'nav-pills']
       end
@@ -24,16 +24,16 @@ module SemanticNavigation
         navigation_default_classes [:nav]
       end
     end
-    
+
     if Rails.env == "production"
       config.after_initialize {
-        load "#{Rails.root}/config/semantic_navigation.rb"
+        load "#{Rails.root}/config/initializers/semantic_navigation.rb"
       }
     else
       ActionDispatch::Callbacks.before {
-        load "#{Rails.root}/config/semantic_navigation.rb"
-      }      
+        load "#{Rails.root}/config/initializers/semantic_navigation.rb"
+      }
     end
-    
+
   end
 end

--- a/lib/semantic_navigation/renderers/acts_as_breadcrumb.rb
+++ b/lib/semantic_navigation/renderers/acts_as_breadcrumb.rb
@@ -1,7 +1,7 @@
 module SemanticNavigation
   module Renderers
     module ActsAsBreadcrumb
-      
+
       def render_navigation(object)
         return '' unless object.render_if
         navigation(object) do
@@ -13,30 +13,30 @@ module SemanticNavigation
             active_element = object.sub_elements.find{|e| e.active}
             active_element.render(self) if active_element
           end
-        end  
+        end
       end
 
       def render_node(object)
         active_element = object.sub_elements.find{|e| e.active}
         if active_element && !active_element.id.in?([except_for].flatten) && active_element.render_if
-          render_element = active_element.render(self)  
+          render_element = active_element.render(self)
         end
         if render_element
           node(object) do
             render_element
-          end          
+          end
         else
           render_leaf(object)
-        end        
+        end
       end
-        
+
       def render_leaf(object)
         show = !until_level.nil? ? object.level <= until_level+1 : true
         return nil unless show
-        
+
         leaf(object)
       end
-      
+
     end
   end
 end

--- a/lib/semantic_navigation/renderers/acts_as_list.rb
+++ b/lib/semantic_navigation/renderers/acts_as_list.rb
@@ -1,47 +1,48 @@
 module SemanticNavigation
   module Renderers
     module ActsAsList
-        
-        def render_navigation(object)
-          return '' unless object.render_if
-          navigation(object) do
-            while !object.class.in?(SemanticNavigation::Core::Leaf, NilClass) && 
-                  from_level.to_i > object.level
-              object = object.sub_elements.find{|e| e.active}
-            end
-            show = !until_level.nil? && !object.nil? ? object.level <= until_level : true
-            if !object.class.in?(SemanticNavigation::Core::Leaf, NilClass) && show
-              object.sub_elements.map{|element| element.render(self)}.compact.sum
-            end
-          end
-        end
 
-        def render_node(object)
-          if !object.id.in?([except_for].flatten) && object.render_if
-            content = render_node_content(object)
-            if content
-              node(object) do
-                content
-              end
-            else
-              render_leaf(object)
-            end  
+      def render_navigation(object)
+        return '' unless object.render_if
+        navigation(object) do
+          while !object.class.in?(SemanticNavigation::Core::Leaf, NilClass) &&
+                from_level.to_i > object.level
+            object = object.sub_elements.find{|e| e.active}
+          end
+          show = !until_level.nil? && !object.nil? ? object.level <= until_level : true
+          if !object.class.in?(SemanticNavigation::Core::Leaf, NilClass) && show
+            object.sub_elements.map{|element| element.render(self)}.compact.sum
           end
         end
-        
-        def render_node_content(object)
-          if (!until_level.nil? && until_level >= object.level) || until_level.nil?
-            node_content(object) do
-              object.sub_elements.map{|element| element.render(self)}.compact.sum
-            end
-          end
-        end
+      end
 
-        def render_leaf(object)
-          if !object.id.in?([except_for].flatten) && object.render_if
-            leaf(object)
+      def render_node(object)
+        if !object.id.in?([except_for].flatten) && object.render_if
+          content = render_node_content(object)
+          if content
+            node(object) do
+              content
+            end
+          else
+            render_leaf(object)
           end
-        end     
+        end
+      end
+
+      def render_node_content(object)
+        if (!until_level.nil? && until_level >= object.level) || until_level.nil?
+          node_content(object) do
+            object.sub_elements.map{|element| element.render(self)}.compact.sum
+          end
+        end
+      end
+
+      def render_leaf(object)
+        if !object.id.in?([except_for].flatten) && object.render_if
+          leaf(object)
+        end
+      end
+
     end
   end
 end

--- a/lib/semantic_navigation/renderers/bread_crumb.rb
+++ b/lib/semantic_navigation/renderers/bread_crumb.rb
@@ -6,22 +6,22 @@ module SemanticNavigation
 
       style_accessor :last_as_link => false,
                      :breadcrumb_separator => '/'
-      
+
       navigation_default_classes [:breadcrumb]
       show_navigation_active_class false
       show_node_active_class false
       show_leaf_active_class false
       show_link_active_class false
-      
+
       private
-      
+
       def navigation(object)
         content_tag :ul, nil, :id => show_id(:navigation, object.id),
                               :class => merge_classes(:navigation, object.active, object.classes) do
           yield
         end
       end
-      
+
       def node(object)
         content_tag(:li, nil, :id => show_id(:leaf, object.id),
                               :class => merge_classes(:leaf, object.active, object.classes)) do
@@ -33,7 +33,7 @@ module SemanticNavigation
         end +
         yield
       end
-     
+
       def leaf(object)
         content_tag :li, nil, :id => show_id(:leaf, object.id),
                               :class => merge_classes(:leaf, object.active, object.classes) do

--- a/lib/semantic_navigation/renderers/list.rb
+++ b/lib/semantic_navigation/renderers/list.rb
@@ -3,34 +3,34 @@ module SemanticNavigation
     class List
       include RenderHelpers
       include ActsAsList
-      
+
       navigation_default_classes [:list]
-      
+
       private
-      
+
       def navigation(object)
         content_tag :ul, nil, :id => show_id(:navigation, object.id),
                               :class => merge_classes(:navigation, object.active, object.classes) do
           yield
         end
       end
-      
+
       def node(object)
         content_tag :li, nil, :id => show_id(:leaf, object.id),
                               :class => merge_classes(:leaf, object.active, object.classes) do
           link_to(object_name(object), object.url, :id => show_id(:link, object.id),
                                            :class => merge_classes(:link, object.active, object.link_classes))+
           yield
-        end 
+        end
       end
-      
+
       def node_content(object)
         content_tag(:ul, nil, :id => show_id(:node, object.id),
                               :class => merge_classes(:node, object.active, object.node_classes)) do
-          yield  
+          yield
         end
       end
-      
+
       def leaf(object)
         content_tag :li, nil, :id => show_id(:leaf, object.id),
                               :class => merge_classes(:leaf, object.active, object.classes) do
@@ -38,7 +38,7 @@ module SemanticNavigation
                                            :class => merge_classes(:link, object.active, object.link_classes)
         end
       end
-      
+
     end
   end
 end

--- a/lib/semantic_navigation/renderers/render_helpers.rb
+++ b/lib/semantic_navigation/renderers/render_helpers.rb
@@ -1,7 +1,7 @@
 module SemanticNavigation
   module Renderers
     module RenderHelpers
-      
+
       def self.included(base)
         base.send :include, InstanceMethods
         base.extend(ClassMethods)
@@ -10,24 +10,24 @@ module SemanticNavigation
                          :node_active_class => [:active],
                          :leaf_active_class => [:active],
                          :link_active_class => [:active],
-      
+
                          :show_navigation_active_class => true,
                          :show_node_active_class => true,
                          :show_leaf_active_class => true,
                          :show_link_active_class => true,
-      
+
                          :show_navigation_id => true,
                          :show_node_id => true,
                          :show_leaf_id => true,
                          :show_link_id => true,
-      
-                         :navigation_default_classes => [], 
+
+                         :navigation_default_classes => [],
                          :node_default_classes => [],
                          :leaf_default_classes => [],
-                         :link_default_classes => []   
+                         :link_default_classes => []
         end
       end
-      
+
       module ClassMethods
 
         def style_accessor(hash)
@@ -50,9 +50,9 @@ module SemanticNavigation
              end
             "
             send key, hash[key]
-          end        
+          end
         end
-        
+
         def property_for(class_name,name)
           class_object = "semantic_navigation/core/#{class_name}".classify.constantize
           class_object.class_eval "
@@ -64,24 +64,24 @@ module SemanticNavigation
           "
         end
       end
-      
-      module InstanceMethods  
+
+      module InstanceMethods
         attr_accessor :from_level, :until_level, :except_for, :name
-        
+
         def level=(level)
           @from_level = level
           @until_level = level
         end
-        
+
         def levels=(level_range)
           @from_level = level_range.first
           @until_level = level_range.last
         end
-        
+
         def initialize
           @view_object = SemanticNavigation::Configuration.view_object
         end
-        
+
         private
 
         def content_tag(tag_name, content = nil, options={}, &block)
@@ -107,9 +107,9 @@ module SemanticNavigation
         def object_name(object)
           object.name(self.name)
         end
-        
+
       end
-  
-    end    
+
+    end
   end
 end

--- a/lib/semantic_navigation/twitter_bootstrap/breadcrumb.rb
+++ b/lib/semantic_navigation/twitter_bootstrap/breadcrumb.rb
@@ -6,9 +6,9 @@ module SemanticNavigation
 
       style_accessor :last_as_link => false,
                      :breadcrumb_separator => '/'
-      
+
       navigation_default_classes [:breadcrumb]
-      
+
       show_navigation_active_class false
       show_node_active_class false
       show_leaf_active_class false
@@ -17,18 +17,18 @@ module SemanticNavigation
       show_node_id false
       show_leaf_id false
       show_link_id false
-      
+
       property_for :base, :ico
-      
+
       private
-      
+
       def navigation(object)
         content_tag :ul, nil, :id => show_id(:navigation, object.id),
                               :class => merge_classes(:navigation, object.active, object.classes) do
           yield
         end
       end
-      
+
       def node(object)
         content_tag(:li, nil, :id => show_id(:leaf, object.id),
                               :class => merge_classes(:leaf, object.active, object.classes)) do
@@ -39,7 +39,7 @@ module SemanticNavigation
         end +
         yield
       end
-     
+
       def leaf(object)
         content_tag :li, nil, :id => show_id(:leaf, object.id),
                               :class => merge_classes(:leaf, object.active, object.classes) do
@@ -52,7 +52,7 @@ module SemanticNavigation
           end].sum
         end
       end
-      
+
     end
   end
 end

--- a/lib/semantic_navigation/twitter_bootstrap/list.rb
+++ b/lib/semantic_navigation/twitter_bootstrap/list.rb
@@ -3,24 +3,24 @@ module SemanticNavigation
     class List
       include SemanticNavigation::Renderers::RenderHelpers
       include SemanticNavigation::Renderers::ActsAsList
-      
+
       navigation_default_classes [:nav, 'nav-list']
       show_navigation_id false
       show_node_id false
       show_leaf_id false
-      show_link_id false      
-      
+      show_link_id false
+
       property_for :base, :ico
-      
+
       private
-      
+
       def navigation(object)
         content_tag :ul, nil, :id => show_id(:navigation, object.id),
                                 :class => merge_classes(:navigation, object.active, object.classes) do
           yield
-        end          
+        end
       end
-      
+
       def node(object)
         if object.ico
           name = [content_tag(:i,nil,:class => "icon-#{object.ico}"),
@@ -28,22 +28,22 @@ module SemanticNavigation
         else
           name = object_name(object)
         end
-        
+
         content_tag :li, nil, :id => show_id(:leaf, object.id),
                               :class => merge_classes(:leaf, object.active, object.classes) do
            link_to(name, object.url, :id => show_id(:link, object.id),
                                             :class => merge_classes(:link, object.active, object.link_classes)) +
           yield
-        end 
+        end
       end
-      
+
       def node_content(object)
         content_tag(:ul, nil, :id => show_id(:node, object.id),
                               :class => merge_classes(:node, object.active, object.node_classes)) do
           yield
         end
       end
-      
+
       def leaf(object)
         if object_name(object).empty? && object.url.nil?
           classes = 'divider'
@@ -52,25 +52,25 @@ module SemanticNavigation
         else
           classes = merge_classes(:leaf, object.active, object.classes)
         end
-        
+
         if object.ico
           name = [content_tag(:i,nil,:class => "icon-#{object.ico}"),
                   object_name(object)].sum
         else
           name = object_name(object)
         end
-                
+
         content_tag :li, nil, :id => show_id(:leaf, object.id),
                               :class => classes do
           if object.url.nil?
             name
           else
             link_to name, object.url, :id => show_id(:link, object.id),
-                                      :class => merge_classes(:link, object.active, object.link_classes)            
+                                      :class => merge_classes(:link, object.active, object.link_classes)
           end
         end
       end
-      
+
     end
   end
 end

--- a/lib/semantic_navigation/twitter_bootstrap/tabs.rb
+++ b/lib/semantic_navigation/twitter_bootstrap/tabs.rb
@@ -3,26 +3,26 @@ module SemanticNavigation
     class Tabs
       include SemanticNavigation::Renderers::RenderHelpers
       include SemanticNavigation::Renderers::ActsAsList
-      
+
       style_accessor :direction => 'left'
-      
+
       navigation_default_classes [:nav, 'nav-tabs']
       show_navigation_id false
       show_node_id false
       show_leaf_id false
-      show_link_id false      
-      
+      show_link_id false
+
       property_for :base, :ico
-      
+
       private
-      
+
       def navigation(object)
         content_tag :ul, nil, :id => show_id(:navigation, object.id),
                               :class => merge_classes(:navigation, object.active, [object.classes,"pull-#{direction}"]) do
           yield
         end
       end
-      
+
       def node(object)
         content_tag :li, nil, :id => show_id(:leaf, object.id),
                               :class => merge_classes(:leaf, object.active, [object.classes,'dropdown'].flatten) do
@@ -33,19 +33,19 @@ module SemanticNavigation
             [object.ico ? content_tag(:i,nil,:class => "icon-#{object.ico}") : '',
              object_name(object),
              content_tag(:b,nil,:class => :caret)
-            ].sum.html_safe                     
+            ].sum.html_safe
           end +
           yield
-        end 
+        end
       end
-      
+
       def node_content(object)
         content_tag(:ul, nil, :id => show_id(:node, object.id),
                               :class => merge_classes(:node, false, [object.node_classes,'dropdown-menu'].flatten)) do
           yield
         end
       end
-      
+
       def leaf(object)
         if object.ico
           name = [content_tag(:i,nil,:class => "icon-#{object.ico}"),
@@ -53,18 +53,18 @@ module SemanticNavigation
         else
           name = object_name(object)
         end
-                
+
         content_tag :li, nil, :id => show_id(:leaf, object.id),
                               :class => merge_classes(:leaf, object.active, object.classes) do
           if object.url.nil?
             name
           else
             link_to name, object.url, :id => show_id(:link, object.id),
-                                             :class => merge_classes(:link, object.active, object.link_classes)            
+                                             :class => merge_classes(:link, object.active, object.link_classes)
           end
         end
       end
-           
+
     end
   end
 end

--- a/spec/lib/semantic_navigation/configuration_spec.rb
+++ b/spec/lib/semantic_navigation/configuration_spec.rb
@@ -1,35 +1,35 @@
 require 'spec_helper'
 
 describe SemanticNavigation::Configuration do
-  
+
   before :each do
     SemanticNavigation::Configuration.class_variable_set("@@navigations",{})
   end
 
   describe "#run" do
-  	it 'should receive class eval if block passed' do
+    it 'should receive class eval if block passed' do
       SemanticNavigation::Configuration.should_receive(:class_eval)
       SemanticNavigation::Configuration.run do
-      	do_something
+        do_something
       end
-  	end
+    end
 
-  	it 'should not receive class_eval if block not passed' do
+    it 'should not receive class_eval if block not passed' do
       SemanticNavigation::Configuration.run
-  	end
+    end
   end
 
   describe '#navigate' do
-  	it 'should receive at least only id and save navigation instance in class variables' do
-  	  nav_instance = SemanticNavigation::Configuration.navigate :some_menu
-  	  navigations = SemanticNavigation::Configuration.class_variable_get("@@navigations")
-  	  navigations.keys.should == [:some_menu]
-  	  navigations[:some_menu].should == nav_instance
-  	end
+    it 'should receive at least only id and save navigation instance in class variables' do
+      nav_instance = SemanticNavigation::Configuration.navigate :some_menu
+      navigations = SemanticNavigation::Configuration.class_variable_get("@@navigations")
+      navigations.keys.should == [:some_menu]
+      navigations[:some_menu].should == nav_instance
+    end
 
     it 'should receive id and pass to Navigation instance create options hash' do
-      SemanticNavigation::Core::Navigation.should_receive(:new).with({:id=>:some_menu, 
-      	                                                              :i18n_name=>"semantic_navigation.some_menu"})
+      SemanticNavigation::Core::Navigation.should_receive(:new).with({:id=>:some_menu,
+                                                                      :i18n_name=>"semantic_navigation.some_menu"})
       SemanticNavigation::Configuration.navigate :some_menu
     end
 
@@ -38,40 +38,40 @@ describe SemanticNavigation::Configuration do
       navigation.should_receive(:instance_eval)
       SemanticNavigation::Core::Navigation.should_receive(:new).and_return navigation
       SemanticNavigation::Configuration.navigate :some_menu do
-      	do_something
+        do_something
       end
     end
 
     it 'should merge id, i18n_name and received params and pass them to navigation instance create method' do
       SemanticNavigation::Core::Navigation.should_receive(:new).with({:id => :some_menu,
-      	                                                              :i18n_name=>"semantic_navigation.some_menu",
-      	                                                              :some_attr => 1,
-      	                                                              :some_attr2 => 2})
+                                                                      :i18n_name=>"semantic_navigation.some_menu",
+                                                                      :some_attr => 1,
+                                                                      :some_attr2 => 2})
       SemanticNavigation::Configuration.navigate :some_menu, :some_attr => 1, :some_attr2 => 2
     end
   end
 
   describe '#navigation' do
-  	it 'should return navigation instance by name' do
-  	  nav_instance = SemanticNavigation::Configuration.navigate :some_menu
+    it 'should return navigation instance by name' do
+      nav_instance = SemanticNavigation::Configuration.navigate :some_menu
       SemanticNavigation::Configuration.navigation(:some_menu).should == nav_instance
-  	end
+    end
   end
 
   describe '#styles_for' do
-  	it 'should save styles block as a proc' do
-  	  proc_object = SemanticNavigation::Configuration.styles_for :some_renderer do
-  	  	do_something1 true
-  	  	do_something2 'some_attr'
-  	  end
-  	  styles = SemanticNavigation::Configuration.class_variable_get("@@render_styles")
-  	  styles[:some_renderer].should == proc_object
+    it 'should save styles block as a proc' do
+      proc_object = SemanticNavigation::Configuration.styles_for :some_renderer do
+        do_something1 true
+        do_something2 'some_attr'
+      end
+      styles = SemanticNavigation::Configuration.class_variable_get("@@render_styles")
+      styles[:some_renderer].should == proc_object
 
-  	  mock_renderer = mock
-  	  mock_renderer.should_receive(:do_something1).with(true)
-  	  mock_renderer.should_receive(:do_something2).with('some_attr')
-  	  mock_renderer.instance_eval &proc_object
-  	end
+      mock_renderer = mock
+      mock_renderer.should_receive(:do_something1).with(true)
+      mock_renderer.should_receive(:do_something2).with('some_attr')
+      mock_renderer.instance_eval &proc_object
+    end
   end
 
   describe '#register_renderer' do
@@ -98,13 +98,13 @@ describe SemanticNavigation::Configuration do
       SemanticNavigation::Configuration.register_renderer :another_name, :some_renderer
       renderers = SemanticNavigation::Configuration.class_variable_get("@@renderers")
       renderers[:another_name].should_not be_nil
-      renderers[:another_name].should == SomeRenderer      
+      renderers[:another_name].should == SomeRenderer
     end
 
     it 'should register a new helper method based on name of a renderer and depending on method navigation_for' do
       SemanticNavigation::Configuration.register_renderer SomeRenderer
       SemanticNavigation::HelperMethods.method_defined?(:some_renderer_for).should be_true
-      
+
       class SomeClass
         include SemanticNavigation::HelperMethods
       end
@@ -117,7 +117,7 @@ describe SemanticNavigation::Configuration do
 
   describe '#render' do
 
-    before :each do 
+    before :each do
       @view_object = mock
       @renderer = mock
       @renderer_instance = mock
@@ -131,7 +131,7 @@ describe SemanticNavigation::Configuration do
     it 'should send render method to Renderer class; mark active navigation elements;' do
       @navigation.should_receive(:mark_active)
       @navigation.should_receive(:render).with(@renderer_instance)
-      @renderer_instance.should_receive(:name=).with(:renderer)      
+      @renderer_instance.should_receive(:name=).with(:renderer)
       SemanticNavigation::Configuration.new.render(:some_menu, :renderer, {}, @view_object)
     end
 
@@ -139,15 +139,15 @@ describe SemanticNavigation::Configuration do
       @navigation.should_receive(:mark_active)
       @navigation.should_receive(:render).with(@renderer_instance)
       @renderer_instance.should_receive(:level=).with(1)
-      @renderer_instance.should_receive(:name=).with(:renderer)      
-      SemanticNavigation::Configuration.new.render(:some_menu, :renderer, {:level => 1}, @view_object)      
+      @renderer_instance.should_receive(:name=).with(:renderer)
+      SemanticNavigation::Configuration.new.render(:some_menu, :renderer, {:level => 1}, @view_object)
     end
 
     it 'should exec default renderer styles from configuration' do
       render_styles = proc{}
       SemanticNavigation::Configuration.class_variable_set "@@render_styles", {:renderer => render_styles}
       @renderer_instance.should_receive(:instance_eval).with(&render_styles)
-      @renderer_instance.should_receive(:name=).with(:renderer)      
+      @renderer_instance.should_receive(:name=).with(:renderer)
       @navigation.should_receive(:mark_active)
       @navigation.should_receive(:render).with(@renderer_instance)
       SemanticNavigation::Configuration.new.render(:some_menu, :renderer, {}, @view_object)
@@ -156,7 +156,7 @@ describe SemanticNavigation::Configuration do
     it 'should set @@view_object in configuration class' do
       @navigation.should_receive(:mark_active)
       @navigation.should_receive(:render).with(@renderer_instance)
-      @renderer_instance.should_receive(:name=).with(:renderer)      
+      @renderer_instance.should_receive(:name=).with(:renderer)
       SemanticNavigation::Configuration.new.render(:some_menu, :renderer, {}, @view_object)
       SemanticNavigation::Configuration.view_object.should == @view_object
     end

--- a/spec/lib/semantic_navigation/custom_renderer.rb
+++ b/spec/lib/semantic_navigation/custom_renderer.rb
@@ -1,3 +1,3 @@
 class CustomRenderer
-  
+
 end

--- a/spec/lib/semantic_navigation/helper_methods_spec.rb
+++ b/spec/lib/semantic_navigation/helper_methods_spec.rb
@@ -10,7 +10,7 @@ describe SemanticNavigation::HelperMethods do
 
   describe "#navigation_for" do
 
-    before :each do 
+    before :each do
       SemanticNavigation::Configuration.stub!(:new).and_return (@config_instance = mock)
     end
 
@@ -41,42 +41,42 @@ describe SemanticNavigation::HelperMethods do
 
     it 'should return name for an active item' do
       SemanticNavigation::Configuration.navigate :some_menu do
-      	item :first, '/first', :name => 'First'
-      	item :second, '/second', :name => 'Second'
-  	  end
-  	  @view_instance.should_receive(:current_page?).with('/first').and_return false
-  	  @view_instance.should_receive(:current_page?).with('/second').and_return true
-  	  result = @view_instance.active_item_for :some_menu
-  	  result.should == 'Second'
+        item :first, '/first', :name => 'First'
+        item :second, '/second', :name => 'Second'
+      end
+      @view_instance.should_receive(:current_page?).with('/first').and_return false
+      @view_instance.should_receive(:current_page?).with('/second').and_return true
+      result = @view_instance.active_item_for :some_menu
+      result.should == 'Second'
     end
 
     it 'should return name for a last level' do
       SemanticNavigation::Configuration.navigate :some_menu do
-      	item :first_node, '/first_node', :name => 'First node' do
-      	  item :first, '/first', :name => 'First'
-      	end
-      	item :second_node, 'second_node', :name => 'Second node' do
-      	  item :second, '/second', :name => 'Second'
-      	end
-  	  end
-  	  @view_instance.should_receive(:current_page?).exactly(4).times.and_return(false, false,true,false) # First, First node, Second, Second node
-  	  result = @view_instance.active_item_for :some_menu
-  	  result.should == 'Second'
-    end    
+        item :first_node, '/first_node', :name => 'First node' do
+          item :first, '/first', :name => 'First'
+        end
+        item :second_node, 'second_node', :name => 'Second node' do
+          item :second, '/second', :name => 'Second'
+        end
+      end
+      @view_instance.should_receive(:current_page?).exactly(4).times.and_return(false, false,true,false) # First, First node, Second, Second node
+      result = @view_instance.active_item_for :some_menu
+      result.should == 'Second'
+    end
 
     it 'should return name for a requested level' do
       SemanticNavigation::Configuration.navigate :some_menu do
-      	item :first_node, '/first_node', :name => 'First node' do
-      	  item :first, '/first', :name => 'First'
-      	end
-      	item :second_node, 'second_node', :name => 'Second node' do
-      	  item :second, '/second', :name => 'Second'
-      	end
-  	  end
-  	  @view_instance.should_receive(:current_page?).exactly(4).times.and_return(false, false,true,false) # First, First node, Second, Second node
-  	  result = @view_instance.active_item_for :some_menu, 1
-  	  result.should == 'Second node'
-    end  
+        item :first_node, '/first_node', :name => 'First node' do
+          item :first, '/first', :name => 'First'
+        end
+        item :second_node, 'second_node', :name => 'Second node' do
+          item :second, '/second', :name => 'Second'
+        end
+      end
+      @view_instance.should_receive(:current_page?).exactly(4).times.and_return(false, false,true,false) # First, First node, Second, Second node
+      result = @view_instance.active_item_for :some_menu, 1
+      result.should == 'Second node'
+    end
 
   end
 

--- a/spec/lib/semantic_navigation/twitter_bootstrap/breadcrumb_spec.rb
+++ b/spec/lib/semantic_navigation/twitter_bootstrap/breadcrumb_spec.rb
@@ -2,33 +2,33 @@ require 'spec_helper'
 
 describe SemanticNavigation::TwitterBootstrap::Breadcrumb do
   before :each do
-  	class ViewObject
-  	  attr_accessor :output_buffer
-  	  include ActionView::Helpers::TagHelper
-  	  include SemanticNavigation::HelperMethods
-  	  include ActionView::Helpers::UrlHelper
-  	end
+        class ViewObject
+          attr_accessor :output_buffer
+          include ActionView::Helpers::TagHelper
+          include SemanticNavigation::HelperMethods
+          include ActionView::Helpers::UrlHelper
+        end
     @configuration = SemanticNavigation::Configuration
-  	@configuration.register_renderer :bootstrap_breadcrumb, SemanticNavigation::TwitterBootstrap::Breadcrumb
-  	@view_object = ViewObject.new
+        @configuration.register_renderer :bootstrap_breadcrumb, SemanticNavigation::TwitterBootstrap::Breadcrumb
+        @view_object = ViewObject.new
   end
 
   it 'should render empty ul tag for empty navigation' do
-  
+
     @configuration.run do
       navigate :menu do
       end
     end
-    
+
     result = @view_object.navigation_for :menu, :as => :bootstrap_breadcrumb
     result.should == "<ul class=\"breadcrumb\"></ul>"
-  end  
+  end
 
   it 'should render one level navigation breadcrumb' do
     @configuration.run do
       navigate :menu do
-      	item :url1, 'url1', :name => 'url1'
-      	item :url2, 'url2', :name => 'url2'
+        item :url1, 'url1', :name => 'url1'
+        item :url2, 'url2', :name => 'url2'
       end
     end
 
@@ -45,12 +45,12 @@ describe SemanticNavigation::TwitterBootstrap::Breadcrumb do
 it 'should render one multilevel navigation breadcrumb' do
     @configuration.run do
       navigate :menu do
-      	item :url1, 'url1', :name => 'url1' do
+        item :url1, 'url1', :name => 'url1' do
           item :suburl1, 'suburl1', :name => 'suburl1'
-      	end
-      	item :url2, 'url2', :name => 'url2' do
+        end
+        item :url2, 'url2', :name => 'url2' do
           item :suburl2, 'suburl2', :name => 'suburl2'
-      	end
+        end
       end
     end
 
@@ -69,17 +69,17 @@ it 'should render one multilevel navigation breadcrumb' do
                           "suburl1",
                         "</li>",
                       "</ul>"].join
-  end  
+  end
 
   it 'should render last item as link if :last_as_link => true' do
     @configuration.run do
       navigate :menu do
-      	item :url1, 'url1', :name => 'url1' do
+        item :url1, 'url1', :name => 'url1' do
           item :suburl1, 'suburl1', :name => 'suburl1'
-      	end
-      	item :url2, 'url2', :name => 'url2' do
+        end
+        item :url2, 'url2', :name => 'url2' do
           item :suburl2, 'suburl2', :name => 'suburl2'
-      	end
+        end
       end
     end
 
@@ -99,18 +99,18 @@ it 'should render one multilevel navigation breadcrumb' do
                             "suburl1",
                           "</a>",
                         "</li>",
-                      "</ul>"].join  	
+                      "</ul>"].join
   end
 
   it 'should render only root level' do
     @configuration.run do
       navigate :menu do
-      	item :url1, 'url1', :name => 'url1' do
+        item :url1, 'url1', :name => 'url1' do
           item :suburl1, 'suburl1', :name => 'suburl1'
-      	end
-      	item :url2, 'url2', :name => 'url2' do
+        end
+        item :url2, 'url2', :name => 'url2' do
           item :suburl2, 'suburl2', :name => 'suburl2'
-      	end
+        end
       end
     end
 
@@ -121,18 +121,18 @@ it 'should render one multilevel navigation breadcrumb' do
                         "<li>",
                           "url1",
                         "</li>",
-                      "</ul>"].join  	
+                      "</ul>"].join
   end
 
   it 'should render second level' do
     @configuration.run do
       navigate :menu do
-      	item :url1, 'url1', :name => 'url1' do
+        item :url1, 'url1', :name => 'url1' do
           item :suburl1, 'suburl1', :name => 'suburl1'
-      	end
-      	item :url2, 'url2', :name => 'url2' do
+        end
+        item :url2, 'url2', :name => 'url2' do
           item :suburl2, 'suburl2', :name => 'suburl2'
-      	end
+        end
       end
     end
 
@@ -143,22 +143,22 @@ it 'should render one multilevel navigation breadcrumb' do
                         "<li>",
                           "suburl1",
                         "</li>",
-                      "</ul>"].join  	
+                      "</ul>"].join
   end
 
   it 'should render the exact levels' do
     @configuration.run do
       navigate :menu do
-      	item :url1, 'url1', :name => 'url1' do
+        item :url1, 'url1', :name => 'url1' do
           item :suburl1, 'suburl1', :name => 'suburl1' do
-          	item :subsub1, 'subsub1', :name => 'subsub1'
+                item :subsub1, 'subsub1', :name => 'subsub1'
           end
-      	end
-      	item :url2, 'url2', :name => 'url2' do
+        end
+        item :url2, 'url2', :name => 'url2' do
           item :suburl2, 'suburl2', :name => 'suburl2' do
-          	item :subsub2, 'subsub2', :name => 'subsub2'
+                item :subsub2, 'subsub2', :name => 'subsub2'
           end
-      	end
+        end
       end
     end
 
@@ -182,21 +182,21 @@ it 'should render one multilevel navigation breadcrumb' do
   it 'should render navigation except some item' do
     @configuration.run do
       navigate :menu do
-      	item :url1, 'url1', :name => 'url1' do
+        item :url1, 'url1', :name => 'url1' do
           item :suburl1, 'suburl1', :name => 'suburl1'
-      	end
-      	item :url2, 'url2', :name => 'url2' do
+        end
+        item :url2, 'url2', :name => 'url2' do
           item :suburl2, 'suburl2', :name => 'suburl2'
-      	end
+        end
       end
     end
-    
+
     @view_object.should_receive(:current_page?).and_return(true, false, false, false)
     result = @view_object.navigation_for :menu, :except_for => [:suburl1], :as => :bootstrap_breadcrumb
     result.should == ["<ul class=\"breadcrumb\">",
                         "<li>",
                           "url1",
                         "</li>",
-                      "</ul>"].join  	
+                      "</ul>"].join
   end
 end

--- a/spec/lib/semantic_navigation/twitter_bootstrap/list_spec.rb
+++ b/spec/lib/semantic_navigation/twitter_bootstrap/list_spec.rb
@@ -3,33 +3,33 @@ require 'spec_helper'
 describe SemanticNavigation::TwitterBootstrap::List do
 
   before :each do
-  	class ViewObject
-  	  attr_accessor :output_buffer
-  	  include ActionView::Helpers::TagHelper
-  	  include SemanticNavigation::HelperMethods
-  	  include ActionView::Helpers::UrlHelper
-  	end
+        class ViewObject
+          attr_accessor :output_buffer
+          include ActionView::Helpers::TagHelper
+          include SemanticNavigation::HelperMethods
+          include ActionView::Helpers::UrlHelper
+        end
     @configuration = SemanticNavigation::Configuration
-  	@configuration.register_renderer :bootstrap_list, SemanticNavigation::TwitterBootstrap::List
-  	@view_object = ViewObject.new
+        @configuration.register_renderer :bootstrap_list, SemanticNavigation::TwitterBootstrap::List
+        @view_object = ViewObject.new
   end
 
   it 'should render empty ul tag for empty navigation' do
-  
+
     @configuration.run do
       navigate :menu do
       end
     end
-    
+
     result = @view_object.navigation_for :menu, :as => :bootstrap_list
     result.should == "<ul class=\"nav nav-list\"></ul>"
-  end  
+  end
 
   it 'should render one level navigation' do
     @configuration.run do
       navigate :menu do
-      	item :url1, 'url1', :name => 'url1'
-      	item :url2, 'url2', :name => 'url2'
+        item :url1, 'url1', :name => 'url1'
+        item :url2, 'url2', :name => 'url2'
       end
     end
 
@@ -51,12 +51,12 @@ describe SemanticNavigation::TwitterBootstrap::List do
 it 'should render one multilevel navigation' do
     @configuration.run do
       navigate :menu do
-      	item :url1, 'url1', :name => 'url1' do
+        item :url1, 'url1', :name => 'url1' do
           item :suburl1, 'suburl1', :name => 'suburl1'
-      	end
-      	item :url2, 'url2', :name => 'url2' do
+        end
+        item :url2, 'url2', :name => 'url2' do
           item :suburl2, 'suburl2', :name => 'suburl2'
-      	end
+        end
       end
     end
 
@@ -87,17 +87,17 @@ it 'should render one multilevel navigation' do
                           "</ul>",
                         "</li>",
                       "</ul>"].join
-  end  
+  end
 
   it 'should render only root level' do
     @configuration.run do
       navigate :menu do
-      	item :url1, 'url1', :name => 'url1' do
+        item :url1, 'url1', :name => 'url1' do
           item :suburl1, 'suburl1', :name => 'suburl1'
-      	end
-      	item :url2, 'url2', :name => 'url2' do
+        end
+        item :url2, 'url2', :name => 'url2' do
           item :suburl2, 'suburl2', :name => 'suburl2'
-      	end
+        end
       end
     end
 
@@ -113,18 +113,18 @@ it 'should render one multilevel navigation' do
                             "url2",
                           "</a>",
                         "</li>",
-                      "</ul>"].join  	
+                      "</ul>"].join
   end
 
   it 'should render second level if some item of first level is active' do
     @configuration.run do
       navigate :menu do
-      	item :url1, 'url1', :name => 'url1' do
+        item :url1, 'url1', :name => 'url1' do
           item :suburl1, 'suburl1', :name => 'suburl1'
-      	end
-      	item :url2, 'url2', :name => 'url2' do
+        end
+        item :url2, 'url2', :name => 'url2' do
           item :suburl2, 'suburl2', :name => 'suburl2'
-      	end
+        end
       end
     end
 
@@ -137,22 +137,22 @@ it 'should render one multilevel navigation' do
                             "suburl1",
                           "</a>",
                         "</li>",
-                      "</ul>"].join  	
+                      "</ul>"].join
   end
 
   it 'should render the exact levels' do
     @configuration.run do
       navigate :menu do
-      	item :url1, 'url1', :name => 'url1' do
+        item :url1, 'url1', :name => 'url1' do
           item :suburl1, 'suburl1', :name => 'suburl1' do
-          	item :subsub1, 'subsub1', :name => 'subsub1'
+                item :subsub1, 'subsub1', :name => 'subsub1'
           end
-      	end
-      	item :url2, 'url2', :name => 'url2' do
+        end
+        item :url2, 'url2', :name => 'url2' do
           item :suburl2, 'suburl2', :name => 'suburl2' do
-          	item :subsub2, 'subsub2', :name => 'subsub2'
+                item :subsub2, 'subsub2', :name => 'subsub2'
           end
-      	end
+        end
       end
     end
 
@@ -182,18 +182,18 @@ it 'should render one multilevel navigation' do
                             "</li>",
                           "</ul>",
                         "</li>",
-                      "</ul>"].join  	
+                      "</ul>"].join
   end
 
   it 'should render navigation except some item' do
     @configuration.run do
       navigate :menu do
-      	item :url1, 'url1', :name => 'url1' do
+        item :url1, 'url1', :name => 'url1' do
           item :suburl1, 'suburl1', :name => 'suburl1'
-      	end
-      	item :url2, 'url2', :name => 'url2' do
+        end
+        item :url2, 'url2', :name => 'url2' do
           item :suburl2, 'suburl2', :name => 'suburl2'
-      	end
+        end
       end
     end
 
@@ -211,18 +211,18 @@ it 'should render one multilevel navigation' do
                             "</li>",
                           "</ul>",
                         "</li>",
-                      "</ul>"].join  	
+                      "</ul>"].join
   end
 
   it 'should render navigation except some items' do
     @configuration.run do
       navigate :menu do
-      	item :url1, 'url1', :name => 'url1' do
+        item :url1, 'url1', :name => 'url1' do
           item :suburl1, 'suburl1', :name => 'suburl1'
-      	end
-      	item :url2, 'url2', :name => 'url2' do
+        end
+        item :url2, 'url2', :name => 'url2' do
           item :suburl2, 'suburl2', :name => 'suburl2'
-      	end
+        end
       end
     end
 
@@ -235,8 +235,8 @@ it 'should render one multilevel navigation' do
                         "<ul>",
                         "</ul>",
                         "</li>",
-                      "</ul>"].join  	
-  end  
+                      "</ul>"].join
+  end
 
   it 'should render divider' do
     @configuration.run do
@@ -283,7 +283,7 @@ it 'should render one multilevel navigation' do
                             "item_name",
                           "</a>",
                         "</li>",
-                      "</ul>"].join    
+                      "</ul>"].join
   end
 
   it 'should render node with icon' do
@@ -310,7 +310,7 @@ it 'should render one multilevel navigation' do
                             "</li>",
                           "</ul>",
                         "</li>",
-                      "</ul>"].join    
+                      "</ul>"].join
   end
 
 end


### PR DESCRIPTION
I think moving configuration to initializers is a better approach to follow conventions. Many other gems use initializers directory to store configuration, devise, rails_admin, simple_form, to name a few. Also removing unnecessary whitespace will improve diff readability and it's make merge operation easier. What do you think?
